### PR TITLE
Update rc_foldersort.php

### DIFF
--- a/rc_foldersort.php
+++ b/rc_foldersort.php
@@ -129,7 +129,7 @@ class rc_foldersort extends rcube_plugin
             );
 
             $folder_sorts = $this->sort_order;
-            if (array_key_exists('default', $folder_sorts)) {
+            if (!empty($folder_sorts) && is_array($folder_sorts) && array_key_exists('default', $folder_sorts)) {
                 $folder_sort = $folder_sorts['default'];
             } else {
                 $folder_sort = 'date_DESC';


### PR DESCRIPTION
To prevent this PHP Warning :
PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /usr/share/roundcubemail/plugins/rc_foldersort/rc_foldersort.php on line 132,
